### PR TITLE
Updated admonition box formatting for jupyter book

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,7 +4,8 @@
 ### Is this service free to use?
 
 Yes! Note, however, that Neuroscout is a web-based engine for fMRI analysis specification; at the moment,
-we don't provide free computing resources for the execution of the resulting analysis bundles. Analyses can be run on Google Colab and a demo notebook is provided [here](https://colab.research.google.com/github/neuroscout/neuroscout-cli/blob/master/examples/Neuroscout_Colab_Demo_NoMount.ipynb).
+we don't provide free computing resources for the execution of the resulting analysis bundles. 
+Analyses can be run on Google Colab and a demo notebook is provided [here](https://colab.research.google.com/github/neuroscout/neuroscout-cli/blob/master/examples/Neuroscout_Colab_Demo_NoMount.ipynb).
 
 ### I plan to publish results I've obtained using Neuroscout, how do I cite?
 

--- a/docs/neuroscout_cli/colab.md
+++ b/docs/neuroscout_cli/colab.md
@@ -1,3 +1,6 @@
 # Running Neuroscout-CLI on Google Colab
 
-A Google colab notebook is available [here](https://colab.research.google.com/github/neuroscout/neuroscout-cli/blob/master/examples/Neuroscout_Colab_Demo_NoMount.ipynb) where you can run a sample pre-generated analysis with an already provided id or provide your own analysis id. To run your own analysis, copy your id into the field in the cell labelled _1) Set Neuroscout Analysis ID_ and then run all of the cells. The provided id will run 10 subjects and 1 run from the Budapest dataset, and may take around 15 minutes. Larger analyses will take longer due to the limited free resources.
+A Google colab notebook is available [here](https://colab.research.google.com/github/neuroscout/neuroscout-cli/blob/master/examples/Neuroscout_Colab_Demo_NoMount.ipynb) where you can run a sample pre-generated analysis with an already provided id or provide your own analysis id. 
+To run your own analysis, copy your id into the field in the cell labelled _1) Set Neuroscout Analysis ID_ and then run all of the cells. 
+The provided id will run 10 subjects and 1 run from the Budapest dataset, and may take around 15 minutes. 
+Larger analyses will take longer due to the limited free resources.

--- a/docs/neuroscout_cli/docker.md
+++ b/docs/neuroscout_cli/docker.md
@@ -2,9 +2,9 @@
 
 ## Quickstart
 
-!!! Note
+```{Note}
     You must have Docker installed on your system
-
+```
 Assuming you've already created an analysis on neuroscout.org, you can run it in one line using the analysis_id (e.g.: `a54oo`):
 
     docker run -it -v /local/dir:/outdir neuroscout/neuroscout-cli run 5xH93 /outdir
@@ -37,8 +37,9 @@ You can also reference a `<version>` in the run command. For example:
 
     docker run -it --rm neuroscout/neuroscout-cli:version-0.5.1 run Mv3ev /out
 
-!!! Note
+```{Note}
     `master` is a special tag name which refers to the most recent _unstable_ commit to GitHub. 
+```
 
 ## Saving outputs to disk
 
@@ -52,9 +53,10 @@ Here we mount the local `/home/user/out` directory to `/out` on the container.:
 
     docker run -it --rm -v /home/user/out:/out neuroscout/neuroscout-cli run 5xH93 /out 
 
-!!! Note
+```{Note}
     After the `run` command, we are telling _neuroscout-cli_ to save the outputs to the `/out` directory on `Docker`,
     which is mapped to `/home/user/out` on our local system.
+```
 
 ### Output derivative structure
 Neuroscout creates a unique output directory `neuroscout-{analysis_id}` for each analysis.
@@ -98,9 +100,9 @@ The resulting cached data directory will look something like this, if you've run
 
 The next time you run a model with a previously downloaded dataset, it will not need to re-download the fMRI data. </br>
 
-!!! important
+```{admonition} Important
     Docker expects **absolute paths** for mounted directories
-
+```
 
 ## Other command line arguments
 

--- a/docs/neuroscout_cli/index.md
+++ b/docs/neuroscout_cli/index.md
@@ -32,9 +32,9 @@ A Google colab notebook is available [here](https://colab.research.google.com/gi
 
 ### Manually prepared environment
 
-!!! Danger
+```{admonition} Danger
     Manually installing _neuroscout-cli_ can be difficult due to complex dependencies. Proceed only if you really need to do this.
-
+```
 Use pip to install _neuroscout-cli_ directly from the GitHub repo:
 
     pip install git+https://www.github.com/neuroscout/neuroscout-cli

--- a/docs/neuroscout_cli/singularity.md
+++ b/docs/neuroscout_cli/singularity.md
@@ -1,10 +1,10 @@
 # Running Neuroscout-CLI on Singularity (High Performance Clusters)
 
-!!! Note
+```{Note}
     Singularity must be available on your HPC. Contact your administrator.
     This guide is for Singularity >= 2.5.
-
-!!! important
+```
+```{admonition} Important
     HPCs typically require jobs to be submitted using a scheduled such as SLURM. 
     This will not be covered in this guide, and will assume commands are run on compute nodes (via interactive sessions or submitted scripts)
 
@@ -25,10 +25,10 @@ You must specify a version.
 You can see the tags available for download on [GitHub Packages](https://github.com/neuroscout/neuroscout-cli/pkgs/container/neuroscout-cli).
 
 
-!!! note
+```{Note}
 `master` is a special tag name which refers to the most recent _unstable_ commit to GitHub. 
 `latest` refers to the latest _stable_ release.
-
+```
 
 ## Executing Singularity image
 
@@ -41,9 +41,9 @@ Where `<outdir>` is a directory you can save files to.
 This command will download the corresponding preprocessed images, event files and model specification, and fit a multi-level GLM model.
 The results will be automatically uploaded to NeuroVault, and the analysis page will link to this upload: https://neuroscout.org/builder/Mv3ev.
 
-!!! important
+```{admonition} Important
     `neuroscout-cli-<version>.simg` refers to a specific downloaded image on your system. 
-
+```
 
 ## Saving data to disk
 

--- a/docs/neuroscout_cli/usage.md
+++ b/docs/neuroscout_cli/usage.md
@@ -1,11 +1,11 @@
 # Neuroscout-CLI Usage
 
-!!! Note
+```{Note}
     If you're just starting out, we suggest you follow our [Docker quickstart](docker.md).
     Remember that if you're using Docker or Singularity, you will have to prepend the following
     commands with the respective container commands (e.g. `docker run -it neuroscout/neuroscout-cli`),
     and mount the appropriate volumes.
-
+```
 
 ## Neuroscout-CLI commands
     
@@ -99,10 +99,10 @@ For example:
 In this case, the fMRI dataset will be downloaded to `/home/user/data` and the output folder will be `/home/user/outputs/neuroscout-a54oo`,
 with the bundle contents saved in the output folder.
 
-!!! Note
+```{Note}
     If you use the `get` command with `--download-dir`, be sure to also specify this directory when calling `run`, otherwise
     the data will be re-downloaded to the output directory.
-
+```
 
 ### Upload
 

--- a/docs/neuroscout_web/browse/clone.md
+++ b/docs/neuroscout_web/browse/clone.md
@@ -32,5 +32,6 @@ Simply select a new dataset from the list, and advance to the `Predictors` tab.
 _Neuroscout_ will attempt to find the same predictors in this dataset, and pre-populate the list of selected predictors.
 If a given predictor cannot be found in this newly selected dataset, it will simply be removed from the model.  
 
-!!! Danger
+```{admonition} Danger
     If a predictor cannot be found in a new dataset, and is removed from the model, all contrasts involving that predictor will also be removed.
+```

--- a/docs/neuroscout_web/browse/index.md
+++ b/docs/neuroscout_web/browse/index.md
@@ -14,8 +14,9 @@ However, you can launch the analysis in "view-only" mode for any analysis, inclu
 
 Remember that for your analyses, you can always change the `name`, `description` and `public/private` status.
 
-!!! Note
+```{Note}
     Instead of "editing" a `PASSED` analysis, you can use the [clone](clone.md) feature to make an editable copy.
+```
 
 ## Deleting analyses
 

--- a/docs/neuroscout_web/builder/review.md
+++ b/docs/neuroscout_web/builder/review.md
@@ -16,9 +16,10 @@ The top plot will give you an overview of the design matrix, with each column of
 
 In the bottom plot, you can explore the predictor time courses in more detail. By clicking on the legend on the right, you can select specific predictors to plot. You may shift-click to select multiple predictors at once.
 
-!!! Note
+```{Note}
     For display purposes, each column is standardized prior to the creation of these plots, even if you did not request a `scale` transformation.
     This force re-scaling will not be performed when creating the actual design matrix.
+```
 
 ### Correlation Matrix
 
@@ -27,8 +28,9 @@ In the bottom plot, you can explore the predictor time courses in more detail. B
 The correlation matrix provides you an opportunity to review the covariance between your predictors.
 Note that predictors that are highly correlated with each other may result in a rank deficient design matrix which will cause model fitting to fail.
 
-!!! Hint
+```{Hint}
     Hover over values in the plot to see the correlation r-values.
+```
 
 ## Analysis Overview
 
@@ -36,6 +38,7 @@ Finally, a complete summary of your analysis is displayed in this tab. Here you 
 
 ![Review overview](img/review_overview.png)
 
-!!! Note
+```{Note}
     Neuroscout stores your model design using BIDS Stats-Model, an in-development JSON standard for representing fMRI models.
     This is the true, final representation of your model, so if you are having problems, or would like to meticulously review your analysis, review this section.
+```

--- a/docs/neuroscout_web/builder/run.md
+++ b/docs/neuroscout_web/builder/run.md
@@ -27,6 +27,7 @@ If your analysis successfully compiles, an example `neuroscout-cli` command will
 
 For more information on how to execute an analysis, head over to the [Run analysis](../cli/index.md) section.
 
-!!! Note
+```{Note}
     After your analysis is compiled, you can change the public/private settings of your analysis, as well as edit the `name` and `description`.
     Also, notice the `Review` tab is still available.
+```


### PR DESCRIPTION
In the transition to jupyter books, note/warning boxes were broken as the markdown syntax is different. I updated all (?) note boxes to use the jupyter book `admonition` [syntax](https://jupyterbook.org/en/stable/content/content-blocks.html#notes-warnings-and-other-admonitions).