### PR TITLE
Typos/suggestions + notes

### DIFF
--- a/docs/python_api/ridge_encoding.ipynb
+++ b/docs/python_api/ridge_encoding.ipynb
@@ -8,11 +8,11 @@
    "source": [
     "# Ridge regression example\n",
     "\n",
-    "This notebook implements a cross-valided voxel-wise encoding model for a single subject using Regularized Ridge Regression.\n",
+    "This notebook implements a cross-validated voxelwise encoding model for a single subject using Regularized Ridge Regression.\n",
     "\n",
     "The goal is to demonstrate how to obtain Neuroscout data to fit models using custom pipelines. For a comprehensive tutorial, check out the excellent [voxelwise modeling tutorials](https://gallantlab.github.io/voxelwise_tutorials/index.html) from the Gallant Lab.\n",
     "\n",
-    "__Note__: By implementing a custom pipeline, your analysis will not be centrally registered on neuroscout.org, and a reproducible record will not be made. For analyses supported the Neuroscout-CLI (e.g. group voxel-wise mass univariate GLM models), it is recommended to use the neuroscout.org web inteface, or follow the guide for programmatically [creating analyses \n",
+    "__Note__: By implementing a custom pipeline, your analysis will not be centrally registered on neuroscout.org, and a reproducible record will not be made. For analyses supported the Neuroscout-CLI (e.g. group voxelwise mass univariate GLM models), it is recommended to use the neuroscout.org web inteface, or follow the guide for programmatically [creating analyses \n",
     "using pyNS](https://pyns.readthedocs.io/en/latest/analyses.html).\n",
     "\n",
     "### Citing Neuroscout\n",
@@ -144,7 +144,7 @@
     "id": "b16buvpOwVn3"
    },
    "source": [
-    "We can easily retrieve data from _Neuroscout_ using __pyNS__-- the Python Neuroscout API client.\n",
+    "We can easily retrieve data from _Neuroscout_ using __pyNS__ -- the Python Neuroscout API client.\n",
     "Be sure to refer to the official [pyNS documentation](https://pyns.readthedocs.io/en/latest/) for further usage information, with particular focus on the section on [fetching predictors and images](https://pyns.readthedocs.io/en/latest/fetching.html)."
    ]
   },
@@ -154,7 +154,7 @@
     "id": "Lrd4z9qEwVn4"
    },
    "source": [
-    "### What data is available?\n",
+    "### What datasets are available?\n",
     "\n",
     "If you're not sure what is available, you can browse Neuroscout's [datasets](https://neuroscout.org/datasets) and [predictors](https://neuroscout.org/predictors) online.\n",
     "\n",
@@ -214,11 +214,11 @@
    "source": [
     "### Fetching predictors \n",
     "\n",
-    "We will fetch two sets of predictors: [Mel spetrogram](https://neuroscout.org/predictor/mel_0), and  [Mel Frequency Cepstral Coefficient (MFCC)](https://neuroscout.org/predictor/mfcc_0). Both of these features are extracted from the auditory track of the movie stimulus ('The Grand Budapest Hotel'). Later in the tutorial we'll fit an encoding model to each set of features separately, and then jointly using a banded model.\n",
+    "We will fetch two sets of predictors: [Mel spetrogram](https://neuroscout.org/predictor/mel_0) and  [Mel Frequency Cepstral Coefficient (MFCC)](https://neuroscout.org/predictor/mfcc_0). Both of these features are extracted from the auditory track of the movie stimulus ('The Grand Budapest Hotel'). Later in the tutorial we'll fit an encoding model to each set of features separately, and then jointly using banded ridge regression.\n",
     "\n",
     "First, we define the names of the predictors we will fetch. \n",
     "\n",
-    "To learn more about basic Neuroscout API querying, see this [guide](https://pyns.readthedocs.io/en/latest/querying.html)"
+    "To learn more about basic Neuroscout API querying, see this [guide](https://pyns.readthedocs.io/en/latest/querying.html)."
    ]
   },
   {
@@ -241,7 +241,7 @@
     "id": "oDMgUdZawVn6"
    },
    "source": [
-    "Next, we can use the high-level utility `fetch_predictors` to retrieve these predictors for the target subject, rescaled using unit variance, and resampled to the imaging data's Repetition Time (TR).\n",
+    "Next, we can use the high-level utility `fetch_predictors` to retrieve these predictors for the target subject, rescaled to unit variance, and resampled to the imaging data's Repetition Time (TR).\n",
     "\n",
     "Since downloading and resampling can take a minute, for this example we'll only use the first three (out of 8) runs."
    ]
@@ -266,7 +266,7 @@
     "id": "RfIuiTB2wVn8"
    },
    "source": [
-    "This results in a dataframe with predictors, plus meta-data such as file entities (e.g. subjects, runs)"
+    "This results in a DataFrame with predictors, plus metadata such as file entities (e.g. subjects, runs)."
    ]
   },
   {
@@ -330,7 +330,7 @@
     "id": "kkcs-xSNwVn-"
    },
    "source": [
-    "`fetch_images` represents images as pybids `BIDSImageFile` objects, which include meta-data such as entities as part of the object"
+    "The `fetch_images` function returns images as pybids `BIDSImageFile` objects, which include metadata such as entities as part of the object:"
    ]
   },
   {
@@ -372,7 +372,7 @@
     "id": "lWe0J6_uwVn_"
    },
    "source": [
-    "Using the entities, we can separate the list of images into two lists: preprocessed functional images, and brain masks"
+    "Using the entities, we can separate the list of images into two lists: preprocessed functional images and brain masks:"
    ]
   },
   {
@@ -402,7 +402,7 @@
     "id": "PotqsQqkwVoA"
    },
    "source": [
-    "The following computes a joint mask for all runs. Alternatively, we could also provide a apriori ROI mask here."
+    "The following computes a joint mask for all runs. Alternatively, we could also provide an a priori ROI mask here."
    ]
   },
   {
@@ -450,7 +450,7 @@
     "id": "jYr3JFuswVoB"
    },
    "source": [
-    "Now we can apply the corresponding brain mask to each run using `NiftiMasker` from `nilearn`, and stack them into a single array for subsequent analysis"
+    "Now we can apply the corresponding brain mask to each run using `NiftiMasker` from `nilearn`, and stack them into a single array for subsequent analysis:"
    ]
   },
   {
@@ -466,7 +466,7 @@
     "from nilearn.maskers import NiftiMasker\n",
     "\n",
     "def _mask_and_stack_images(image_objects, mask):\n",
-    "    \"\"\" Stack images into single array, and collect metadata entities into dataframe \"\"\"\n",
+    "    \"\"\" Stack images into single array, and collect metadata entities into DataFrame \"\"\"\n",
     "    masker = NiftiMasker(mask_img=mask)\n",
     "\n",
     "    arrays = []\n",
@@ -497,7 +497,7 @@
     "id": "CMV_4wJOwVoC"
    },
    "source": [
-    "The stacked runs have shape: (n_volumes, n_voxels)"
+    "The stacked runs have shape: `(n_volumes, n_voxels)`"
    ]
   },
   {
@@ -532,7 +532,7 @@
     "id": "gY6W9LKrwVoD"
    },
    "source": [
-    "We also keep the entities associated with each volume in a dataframe:"
+    "We also keep the entities associated with each volume in a DataFrame:"
    ]
   },
   {
@@ -829,7 +829,7 @@
     "id": "4s6bS-TfwVoE"
    },
    "source": [
-    "## Fitting Ridge regression model using melspectrogram features"
+    "## Fitting ridge regression models using Mel spectrogram features"
    ]
   },
   {
@@ -838,15 +838,15 @@
     "id": "A_y8miXrwVoE"
    },
    "source": [
-    "First, we'll fit a basic Ridge regression model to a subset of voxels (for demonstration purposes).\n",
+    "First, we'll fit a basic voxelwise ridge regression model to a subset of voxels (for demonstration purposes).\n",
     "\n",
-    "We'll define two cross-validators: an outer and an inner cv. The outer cross-validator will loop be used to estimate the performance of the model on unseen data, and the inner cv will be used to select the alpha hyperparameter for Ridge regression, within each fold of the outer cross-validator.\n",
+    "We'll define two cross-validators: outer and inner CV. The outer cross-validator loop will be used to estimate the performance of the model on unseen data, and the inner cross-validator will be used to select the alpha hyperparameter for ridge regression within each training fold of the outer cross-validator.\n",
     "\n",
     "In both cases, we'll use the leave-one-run-out strategy, testing the model on an unseen run. Since there are multiple observations per run, we use the`run` column of `X_entities` to group observations, and ensure they appear together within each fold.\n",
     "\n",
     "Finally, we also define a scoring function, in this case, `correlation_score`.\n",
     "\n",
-    "Note that we are using the `himalaya` library's `KernelRidgeCV` estimator, as it is optimized for multi-target (i.e. voxel) estimation & hyperparameter optimization with a sklearn-like API."
+    "Note that we are using the `himalaya` library's `KernelRidgeCV` estimator, as it is optimized for multi-target (i.e. voxel) estimation and hyperparameter optimization with an API inspired by scikit-learn."
    ]
   },
   {
@@ -892,7 +892,7 @@
     "id": "lWpqeNTlwVoF"
    },
    "source": [
-    "The following is a generic pipeline for applying the esimator to the data (including support for banded-regression, which we'll discuss later)"
+    "The following is a generic pipeline for applying the estimator to the data (including support for banded ridge regression, which we'll discuss later)."
    ]
   },
   {
@@ -969,7 +969,7 @@
     "id": "2vdcFXmzwVoG"
    },
    "source": [
-    "First, we'll fit this model using only the mel-spectrogram features:"
+    "First, we'll fit this model using only the Mel spectrogram features:"
    ]
   },
   {
@@ -990,7 +990,7 @@
     "id": "FBulqpOOwVoH"
    },
    "source": [
-    "The `result` dictionary contains:"
+    "The `results` dictionary contains:"
    ]
   },
   {
@@ -1022,7 +1022,7 @@
     "id": "jK0jYAjawVoH"
    },
    "source": [
-    "The `test_scores` & coefficients are of shape: (n_folds, n_voxels)."
+    "The `test_scores` and coefficients are of shape: `(n_folds, n_voxels)`."
    ]
   },
   {
@@ -1057,7 +1057,7 @@
     "id": "U0di3GRTwVoI"
    },
    "source": [
-    "We can average across folds, and only take positive scores:"
+    "We can average across folds:"
    ]
   },
   {
@@ -1070,7 +1070,6 @@
    "outputs": [],
    "source": [
     "mean_scores = results['test_scores'].mean(axis=0)\n",
-    "mean_scores[mean_scores < 0] = 0"
    ]
   },
   {
@@ -1201,7 +1200,7 @@
     "id": "x3-luiNLwVoK"
    },
    "source": [
-    "We can now run a similar model, but using MFCC featues, instead of the mel-spectrogram"
+    "We can now run a similar model, but using MFCC featues, instead of the Mel spectrogram"
    ]
   },
   {
@@ -1234,7 +1233,7 @@
     "id": "s0lFFjkowVoK"
    },
    "source": [
-    "From looking at whole-brain scores, the MFCC model outperforms the mel-spectrogram model"
+    "From looking at whole-brain scores, the MFCC model may outperform the Mel spectrogram model:"
    ]
   },
   {
@@ -1356,13 +1355,13 @@
     "id": "ZAueZ-O4K3OS"
    },
    "source": [
-    "Due to the hemodynamic response lag, it's likely the model would perform better if the predictors were delayed.\n",
+    "Due to the hemodynamic lag, the model may perform better if the predictors were delayed relative to the stimulus onset.\n",
     "\n",
-    "We can do so using a Finite Impulse Response (fir) model. \n",
+    "We can do so using a Finite Impulse Response (FIR) model. \n",
     "\n",
     "Using `fetch_predictors`, we can ask for the predictors to be returned as a `BIDSVariableCollection`, which enables us to apply any of the transformations implemented in pybids. \n",
     "\n",
-    "Alternatively, you could apply any arbitrary transformations, by requesting a pandas data-frame. "
+    "Alternatively, you could apply any arbitrary transformations, by requesting a pandas DataFrame. "
    ]
   },
   {
@@ -1383,7 +1382,7 @@
     "id": "ewGKatCkK8GM"
    },
    "source": [
-    "Next, we using `Convolve` to apply a `fir` model, and convert to a pandas df"
+    "Next, we using `Convolve` to apply a `fir` model, and convert to a pandas DataFrame:"
    ]
   },
   {
@@ -1444,9 +1443,9 @@
     "id": "mZ_MfqTRLRaG"
    },
    "source": [
-    "The FIR convolution results in 5x amount of predictors, including the delayed version of the predictors.\n",
+    "The FIR convolution results in 5x amount of predictors, including the delayed versions of the predictors.\n",
     "\n",
-    "We can now fit a model with all the mel-spectrogram features, to see if that improves prediction"
+    "We can now fit a model with all the Mel spectrogram features to see if it improves prediction:"
    ]
   },
   {
@@ -1479,7 +1478,7 @@
     "id": "ZuQOluTDLYj0"
    },
    "source": [
-    "The max score increases, while the mean score remains similar (although marginally higher)"
+    "The max score increases, while the mean score remains similar (although marginally higher):"
    ]
   },
   {
@@ -1588,11 +1587,11 @@
    "source": [
     "The goal of this tutorial is to familiarize you with how to access Neuroscout's data to fit custom models.\n",
     "\n",
-    "This tutorial does not exhaustively cover all possible models that can be fit using these data, but at this point you should have the tool necessary to access the necessary data from NeuroScout's API.\n",
+    "This tutorial does not exhaustively cover all possible models that can be fit using these data, but at this point you should have the tools necessary to access the data from NeuroScout's API.\n",
     "\n",
     "By being able to fetch both predictor and brain imaging time courses using a simple, uniform API, it should be easy to extend these examples to a wide variety of machine learning workflows.\n",
     "\n",
-    "Please ensure to cite Neuroscout if publishing any work using these data, and be aware that there are ongoing efforts to standardize the most common variations of voxel-wise encoding models, in order to enable users to fully specify and register their analysis in Neuroscout (like you currently can for summary-statistics multi-level GLM models). "
+    "Please ensure to cite Neuroscout if publishing any work using these data, and be aware that there are ongoing efforts to standardize the most common variations of voxelwise encoding models, in order to enable users to fully specify and register their analysis in Neuroscout (like you currently can for summary-statistics multi-level GLM models). "
    ]
   }
  ],

--- a/docs/python_api/ridge_encoding.ipynb
+++ b/docs/python_api/ridge_encoding.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Ridge regression example\n",
     "\n",
-    "This notebook implements a cross-validated voxelwise encoding model for a single subject using Regularized Ridge Regression.\n",
+    "This notebook implements a cross-valided voxelwise encoding model for a single subject using Regularized Ridge Regression.\n",
     "\n",
     "The goal is to demonstrate how to obtain Neuroscout data to fit models using custom pipelines. For a comprehensive tutorial, check out the excellent [voxelwise modeling tutorials](https://gallantlab.github.io/voxelwise_tutorials/index.html) from the Gallant Lab.\n",
     "\n",
@@ -144,7 +144,8 @@
     "id": "b16buvpOwVn3"
    },
    "source": [
-    "We can easily retrieve data from _Neuroscout_ using __pyNS__ -- the Python Neuroscout API client.\n",
+    "We can easily retrieve data from _Neuroscout_ using __pyNS__ — the Python Neuroscout API client.\n",
+    "\n",
     "Be sure to refer to the official [pyNS documentation](https://pyns.readthedocs.io/en/latest/) for further usage information, with particular focus on the section on [fetching predictors and images](https://pyns.readthedocs.io/en/latest/fetching.html)."
    ]
   },
@@ -214,7 +215,7 @@
    "source": [
     "### Fetching predictors \n",
     "\n",
-    "We will fetch two sets of predictors: [Mel spetrogram](https://neuroscout.org/predictor/mel_0) and  [Mel Frequency Cepstral Coefficient (MFCC)](https://neuroscout.org/predictor/mfcc_0). Both of these features are extracted from the auditory track of the movie stimulus ('The Grand Budapest Hotel'). Later in the tutorial we'll fit an encoding model to each set of features separately, and then jointly using banded ridge regression.\n",
+    "We will fetch two sets of predictors: [Mel spetrogram](https://neuroscout.org/predictor/mel_0), and  [Mel Frequency Cepstral Coefficient (MFCC)](https://neuroscout.org/predictor/mfcc_0). Both of these features are extracted from the auditory track of the movie stimulus ('The Grand Budapest Hotel'). Later in the tutorial we'll fit an encoding model to each set of features separately. \n",
     "\n",
     "First, we define the names of the predictors we will fetch. \n",
     "\n",
@@ -250,8 +251,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "id": "DHlQV2P_wVn7",
-    "scrolled": false
+    "id": "DHlQV2P_wVn7"
    },
    "outputs": [],
    "source": [
@@ -266,7 +266,7 @@
     "id": "RfIuiTB2wVn8"
    },
    "source": [
-    "This results in a DataFrame with predictors, plus metadata such as file entities (e.g. subjects, runs)."
+    "This results in a `DataFrame` with predictors, plus metadata such as file entities (e.g. subjects, runs)"
    ]
   },
   {
@@ -291,8 +291,7 @@
      "base_uri": "https://localhost:8080/"
     },
     "id": "OePmkXlPwVn9",
-    "outputId": "1fbc61c2-528d-4075-929b-44c41e28d8c2",
-    "scrolled": false
+    "outputId": "1fbc61c2-528d-4075-929b-44c41e28d8c2"
    },
    "outputs": [
     {
@@ -330,7 +329,7 @@
     "id": "kkcs-xSNwVn-"
    },
    "source": [
-    "The `fetch_images` function returns images as pybids `BIDSImageFile` objects, which include metadata such as entities as part of the object:"
+    "The `fetch_images` function returns images as pybids `BIDSImageFile` objects, which include metadata such as entities as part of the object"
    ]
   },
   {
@@ -402,7 +401,7 @@
     "id": "PotqsQqkwVoA"
    },
    "source": [
-    "The following computes a joint mask for all runs. Alternatively, we could also provide an a priori ROI mask here."
+    "The following computes a joint mask for all runs. Alternatively, we could also provide a apriori ROI mask here."
    ]
   },
   {
@@ -455,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "metadata": {
     "id": "t_O9Bx8qwVoB"
    },
@@ -532,7 +531,7 @@
     "id": "gY6W9LKrwVoD"
    },
    "source": [
-    "We also keep the entities associated with each volume in a DataFrame:"
+    "We also keep the entities associated with each volume in a dataframe:"
    ]
   },
   {
@@ -840,13 +839,13 @@
    "source": [
     "First, we'll fit a basic voxelwise ridge regression model to a subset of voxels (for demonstration purposes).\n",
     "\n",
-    "We'll define two cross-validators: outer and inner CV. The outer cross-validator loop will be used to estimate the performance of the model on unseen data, and the inner cross-validator will be used to select the alpha hyperparameter for ridge regression within each training fold of the outer cross-validator.\n",
+    "We'll define two cross-validators: an outer and an inner CV. The outer cross-validator will loop will be used to estimate the performance of the model on unseen data, and the inner cross-validator will be used to select the alpha hyperparameter for ridge regression, within each training fold of the outer cross-validator.\n",
     "\n",
     "In both cases, we'll use the leave-one-run-out strategy, testing the model on an unseen run. Since there are multiple observations per run, we use the`run` column of `X_entities` to group observations, and ensure they appear together within each fold.\n",
     "\n",
     "Finally, we also define a scoring function, in this case, `correlation_score`.\n",
     "\n",
-    "Note that we are using the `himalaya` library's `KernelRidgeCV` estimator, as it is optimized for multi-target (i.e. voxel) estimation and hyperparameter optimization with an API inspired by scikit-learn."
+    "Note that we are using the `himalaya` library's `KernelRidgeCV` estimator, as it is optimized for multi-target (i.e. voxel) estimation & hyperparameter optimization with an API inspired by scikit-learn."
    ]
   },
   {
@@ -892,7 +891,7 @@
     "id": "lWpqeNTlwVoF"
    },
    "source": [
-    "The following is a generic pipeline for applying the estimator to the data (including support for banded ridge regression, which we'll discuss later)."
+    "The following is a generic pipeline for applying the estimator to the data:"
    ]
   },
   {
@@ -1057,19 +1056,36 @@
     "id": "U0di3GRTwVoI"
    },
    "source": [
-    "We can average across folds:"
+    "Then, we average across folds to get the mean score across for this subject:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 18,
    "metadata": {
-    "id": "ZXEz361JwVoI",
-    "scrolled": false
+    "id": "ZXEz361JwVoI"
    },
    "outputs": [],
    "source": [
-    "mean_scores = results['test_scores'].mean(axis=0)\n",
+    "mean_scores = results['test_scores'].mean(axis=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For interpretation only, we'll only look at positive scores:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "id": "ZXEz361JwVoI"
+   },
+   "outputs": [],
+   "source": [
+    "mean_scores[mean_scores < 0] = 0"
    ]
   },
   {
@@ -1233,7 +1249,7 @@
     "id": "s0lFFjkowVoK"
    },
    "source": [
-    "From looking at whole-brain scores, the MFCC model may outperform the Mel spectrogram model:"
+    "From looking at whole-brain scores, the MFCC mdoel may outperform the Mel spectrogram model:"
    ]
   },
   {
@@ -1361,7 +1377,7 @@
     "\n",
     "Using `fetch_predictors`, we can ask for the predictors to be returned as a `BIDSVariableCollection`, which enables us to apply any of the transformations implemented in pybids. \n",
     "\n",
-    "Alternatively, you could apply any arbitrary transformations, by requesting a pandas DataFrame. "
+    "Alternatively, you could apply any arbitrary transformations, by requesting a pandas DataFrame."
    ]
   },
   {
@@ -1382,16 +1398,28 @@
     "id": "ewGKatCkK8GM"
    },
    "source": [
-    "Next, we using `Convolve` to apply a `fir` model, and convert to a pandas DataFrame:"
+    "Next, we use `Convolve` to apply a `fir` model, and convert to a pandas df"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 2,
    "metadata": {
     "id": "GGH0IFl1LGZp"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'collection' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m/tmp/ipykernel_509096/513582641.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     14\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mcollection_df\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     15\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 16\u001b[0;31m \u001b[0mcollection_df\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_convolve_df\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcollection\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mall_vars\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'collection' is not defined"
+     ]
+    }
+   ],
    "source": [
     "from bids.modeling.transformations import Convolve\n",
     "\n",
@@ -1445,7 +1473,7 @@
    "source": [
     "The FIR convolution results in 5x amount of predictors, including the delayed versions of the predictors.\n",
     "\n",
-    "We can now fit a model with all the Mel spectrogram features to see if it improves prediction:"
+    "We can now fit a model with all the Mel spectrogram features, to see if it improves prediction:"
    ]
   },
   {
@@ -1587,12 +1615,25 @@
    "source": [
     "The goal of this tutorial is to familiarize you with how to access Neuroscout's data to fit custom models.\n",
     "\n",
-    "This tutorial does not exhaustively cover all possible models that can be fit using these data, but at this point you should have the tools necessary to access the data from NeuroScout's API.\n",
+    "This tutorial does not exhaustively cover all possible models that can be fit using these data, but at this point you should have the tools necessary to access the necessary data from NeuroScout's API.\n",
     "\n",
-    "By being able to fetch both predictor and brain imaging time courses using a simple, uniform API, it should be easy to extend these examples to a wide variety of machine learning workflows.\n",
-    "\n",
-    "Please ensure to cite Neuroscout if publishing any work using these data, and be aware that there are ongoing efforts to standardize the most common variations of voxelwise encoding models, in order to enable users to fully specify and register their analysis in Neuroscout (like you currently can for summary-statistics multi-level GLM models). "
+    "By being able to fetch both predictor and brain imaging time courses using a simple, uniform API, it should be easy to extend these examples to a wide variety of machine learning workflows."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Citing Neuroscout\n",
+    "Please ensure to cite Neuroscout if publishing any work using these data, and be aware that there are ongoing efforts to standardize the most common variations of voxel-wise encoding models, in order to enable users to fully specify and register their analysis in Neuroscout (like you currently can for summary-statistics multi-level GLM models). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1619,5 +1660,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
PR from @snastase

Mostly cosmetic changes in the Markdown (typos and wording suggestions). A few notes:

1. I wouldn't take only positive when computing the mean test scores across folds (unless it really screws things up not to)—I don't think this is standard procedure. I removed the line where this happens.

2. At line 1025 it's kind of hard to tell where the shape of the coefficients is coming from.

3. The MFCC features actually seem to light up left early auditory cortex pretty well in the second brain plot—nice! You might consider putting in a caveat with these brain images that we haven't corrected for multiple tests in any way.

4. Not sure I understand why `Convolve` returns 5 models if you ask for 4 lags (i.e. why "5x" at line 1446?). Does it include the non-lagged version? In Gallant's work, they would typically _only_ used the four lagged versions.

5. I don't see any